### PR TITLE
Conditionally render <RightContent>

### DIFF
--- a/src/components/Lane.js
+++ b/src/components/Lane.js
@@ -135,9 +135,10 @@ class Lane extends Component {
           <Title style={titleStyle}>
             {title}
           </Title>
+          {label !== "" &&
           <RightContent>
             {label}
-          </RightContent>
+          </RightContent>}
         </Header>
         {this.renderDragContainer()}
         {loading && <Loader />}

--- a/src/components/Lane.js
+++ b/src/components/Lane.js
@@ -135,7 +135,7 @@ class Lane extends Component {
           <Title style={titleStyle}>
             {title}
           </Title>
-          {label !== "" &&
+          {label !== '' &&
           <RightContent>
             {label}
           </RightContent>}


### PR DESCRIPTION
I'd like `Title` to take up 100% of the header by setting width in `titleStyle`. New to react; sorry if this is not idiomatic.