### PR TITLE
Droppable lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This is the container component that encapsulates the lanes and cards
 | Name             | Type     | Description                              |
 | ---------------- | -------- | ---------------------------------------- |
 | draggable        | boolean  | Makes all cards in the lanes draggable. Default: false |
+| droppable        | boolean  | Makes a lane draggable. Default: true   |
 | handleDragStart  | function | Callback function triggered when card drag is started: `handleDragStart(cardId, laneId)` |
 | handleDragEnd    | function | Callback function triggered when card drag ends: `handleDragEnd(cardId, sourceLaneId, targetLaneId)` |
 | onLaneScroll     | function | Called when a lane is scrolled to the end: `onLaneScroll(requestedPage, laneId)` |

--- a/react-trello.iml
+++ b/react-trello.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/components/BoardContainer.js
+++ b/src/components/BoardContainer.js
@@ -52,13 +52,14 @@ class BoardContainer extends Component {
     return (
       <BoardDiv style={style} {...otherProps}>
         {reducerData.lanes.map(lane => {
-          const {id, ...otherProps} = lane
+          const {id, droppable, ...otherProps} = lane
           const passthroughProps = pick(this.props, [
             'onLaneScroll',
             'onCardClick',
             'onLaneClick',
             'laneSortFunction',
             'draggable',
+            'droppable',
             'handleDragStart',
             'handleDragEnd',
             'customCardLayout',
@@ -66,7 +67,7 @@ class BoardContainer extends Component {
             'tagStyle',
             'children'
           ])
-          return <Lane key={`${id}`} id={id} {...otherProps} {...passthroughProps} />
+          return <Lane key={`${id}`} id={id} droppable={droppable === undefined ? true : droppable} {...otherProps} {...passthroughProps} />
         })}
       </BoardDiv>
     )
@@ -82,6 +83,7 @@ BoardContainer.propTypes = {
   onLaneClick: PropTypes.func,
   laneSortFunction: PropTypes.func,
   draggable: PropTypes.bool,
+  droppable: PropTypes.bool,
   handleDragStart: PropTypes.func,
   handleDragEnd: PropTypes.func,
   customCardLayout: PropTypes.bool,

--- a/src/components/Lane.js
+++ b/src/components/Lane.js
@@ -94,7 +94,7 @@ class Lane extends Component {
   }
 
   moveCardAcrossLanes = (fromLaneId, toLaneId, cardId) => {
-    this.props.actions.moveCardAcrossLanes({fromLaneId: fromLaneId, toLaneId: toLaneId, cardId: cardId})
+    toLaneId && this.props.actions.moveCardAcrossLanes({fromLaneId: fromLaneId, toLaneId: toLaneId, cardId: cardId})
   }
 
   removeCard = (laneId, cardId) => {
@@ -207,6 +207,10 @@ Lane.defaultProps = {
 }
 
 const cardTarget = {
+  canDrop(props) {
+    return props.droppable
+  },
+
   drop (props, monitor, component) {
     const {id} = props
     const draggedObj = monitor.getItem()
@@ -225,7 +229,6 @@ const cardTarget = {
     if (id === draggedObj.laneId) {
       return
     }
-
     const placeholderIndex = getPlaceholderIndex(monitor.getClientOffset().y, findDOMNode(component).scrollTop)
     component.setState({placeholderIndex})
 

--- a/src/components/Lane.js
+++ b/src/components/Lane.js
@@ -207,7 +207,7 @@ Lane.defaultProps = {
 }
 
 const cardTarget = {
-  canDrop(props) {
+  canDrop (props) {
     return props.droppable
   },
 

--- a/stories/data.json
+++ b/stories/data.json
@@ -33,8 +33,9 @@
     },
     {
       "id": "WIP",
-      "title": "Work In Progress",
+      "title": "Work In Progress (Not Droppable)",
       "label": "10/20",
+      "droppable": false,
       "cards": [
         {
           "id": "Wip1",


### PR DESCRIPTION
Prevent card dropping to lanes specified with droppable prop. Can also be globally set on the Board component. Defaults to `true`