### PR TITLE
Add hover placeholder index update debouncing

### DIFF
--- a/src/components/Lane.js
+++ b/src/components/Lane.js
@@ -21,7 +21,8 @@ class Lane extends Component {
     loading: false,
     currentPage: this.props.currentPage,
     cards: this.props.cards,
-    placeholderIndex: -1
+    placeholderIndex: -1,
+    shouldUpdate: true
   }
 
   handleScroll = evt => {
@@ -227,7 +228,11 @@ const cardTarget = {
     }
 
     const placeholderIndex = getPlaceholderIndex(monitor.getClientOffset().y, findDOMNode(component).scrollTop)
-    component.setState({placeholderIndex})
+
+    if (component.state.shouldUpdate) {
+      component.setState({ placeholderIndex: placeholderIndex, shouldUpdate: false })
+      setTimeout(() => component.setState({ shouldUpdate: true }), 50)
+    }
 
     return monitor.isOver()
 


### PR DESCRIPTION
Fix poor performance of cross lane card moving with large number of cards( More than 20, if 20 is a large number :D). Issue is caused by Lane component re-rendering insanely due to the `onHover` DnD callback setting of the `placeholderIndex` state property. Quick fixing it with `setState` debouncing.