### PR TITLE
make move card across lanes available to the outside user

### DIFF
--- a/src/components/BoardContainer.js
+++ b/src/components/BoardContainer.js
@@ -23,6 +23,8 @@ class BoardContainer extends Component {
             return actions.removeCard({laneId: event.laneId, cardId: event.cardId})
           case 'REFRESH_BOARD':
             return actions.loadBoard(event.data)
+          case 'MOVE_CARD':
+            return actions.moveCardAcrossLanes({fromLaneId: event.fromLaneId, toLaneId: event.toLaneID, cardId: event.cardId, index: event.index})
         }
       }
     }


### PR DESCRIPTION
This Pullrequest makes the action to move cards to other lanes available to the outside user.

It's much easier to handle than to remove and add a card.