### PR TITLE
Fixing react error that occurs if user tries to add same card twice

### DIFF
--- a/src/helpers/LaneHelper.js
+++ b/src/helpers/LaneHelper.js
@@ -17,14 +17,17 @@ const LaneHelper = {
   },
 
   appendCardsToLane: (state, {laneId, newCards, index}) => {
-    newCards = newCards.map(c => update(c, {laneId: {$set: laneId}}))
+    const lane = state.lanes.find(lane => lane.id === laneId)
+    newCards = newCards
+      .map(c => update(c, {laneId: {$set: laneId}}))
+      .filter(c => lane.cards.find(card => card.id === c.id) == null)
     return state.lanes.map(lane => {
       if (lane.id === laneId) {
         if (index !== undefined) {
           return update(lane, {cards: {$splice: [[index, 0, ...newCards]]}})
         } else {
-					const cardsToUpdate = [...lane.cards, ...newCards]
-					return update(lane, {cards: {$set: cardsToUpdate}})
+          const cardsToUpdate = [...lane.cards, ...newCards]
+          return update(lane, {cards: {$set: cardsToUpdate}})
         }
       } else {
         return lane


### PR DESCRIPTION
If a user (me ;) ) tries to add the same card twice, `react-trello` will generate a react error.

```
warning.js:33 Warning: Encountered two children with the same key, `Ec2Error`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```
This PR will filter cards that are already available.

Improvement suggestion:
If you commit something, I would suggest to:
a) run `yarn run lintfix` as there are some lint errors
b) add some tests. the storyboard is awesome, but for contributors it would be nice to at least have some tests that check the crucial parts.

I've tried to maintain your code format, but a yarn task `reformat`would also be nice ;)

Thanks by the way, I like your code style.