### PR TITLE
remove unused variable `shouldUpdate`

### DIFF
--- a/src/components/Lane.js
+++ b/src/components/Lane.js
@@ -19,7 +19,6 @@ class Lane extends Component {
     loading: false,
     currentPage: this.props.currentPage,
     cards: this.props.cards,
-    shouldUpdate: true,
     addCardMode: false
   }
 


### PR DESCRIPTION
I was mistaken when creating #72 but I'm pretty sure that, this time, the proposed change should, as intended, have no effect. I can find no references to `shouldUpdate` in the file nor anywhere it could leak elsewhere.