### PR TITLE
remove unused `className` prop from EditableLabel

### DIFF
--- a/src/components/widgets/EditableLabel.js
+++ b/src/components/widgets/EditableLabel.js
@@ -31,7 +31,7 @@ class EditableLabel extends React.Component {
 
   getClassName = () => {
     const placeholder = this.state.text === '' ? 'comPlainTextContentEditable--has-placeholder' : ''
-    return `comPlainTextContentEditable ${placeholder} ${this.props.className}`
+    return `comPlainTextContentEditable ${placeholder}`
   }
 
   render() {
@@ -52,13 +52,11 @@ class EditableLabel extends React.Component {
 EditableLabel.defaultProps = {
   onChange: () => {},
   placeholder: '',
-  className: '',
   autoFocus: false
 }
 EditableLabel.propTypes = {
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
-  className: PropTypes.string,
   autoFocus: PropTypes.bool
 }
 


### PR DESCRIPTION
I think this should be safe to remove..

[project references to `EditableLabel`](https://github.com/rcdexta/react-trello/search?utf8=%E2%9C%93&q=EditableLabel&type=)
[the only consumer](https://github.com/rcdexta/react-trello/blob/2c5a0b401df64bd3306ffd7cb90d7a3752332c09/src/components/NewCard.js) doesn't seem to pass `className`