### PR TITLE
remove dead code - moveCard method in Lane

### DIFF
--- a/src/components/Lane.js
+++ b/src/components/Lane.js
@@ -61,19 +61,6 @@ class Lane extends Component {
     }
   }
 
-  moveCard = (dragIndex, hoverIndex) => {
-    const {cards} = this.state
-    const dragCard = cards[dragIndex]
-
-    this.setState(
-      update(this.state, {
-        cards: {
-          $splice: [[dragIndex, 1], [hoverIndex, 0, dragCard]]
-        }
-      })
-    )
-  }
-
   componentWillReceiveProps(nextProps) {
     if (!isEqual(this.props.cards, nextProps.cards)) {
       this.setState({
@@ -148,7 +135,6 @@ class Lane extends Component {
         customCard={this.props.children}
         tagStyle={tagStyle}
         cardStyle={cardStyle}
-        moveCard={this.moveCard}
         removeCard={this.removeCard}
         onClick={e => this.handleCardClick(e, card)}
         onDelete={this.props.onCardDelete}


### PR DESCRIPTION
Hi again!

There may be a better fix for this then straight removal but I noticed that this code is unused so removing it should have no effect.

I could be mistaken so please confirm independently. My reasoning follows:
- Besides the declaration, the only reference to `moveCard` in Lane.js is [where it is passed to Card](https://github.com/rcdexta/react-trello/blob/master/src/components/Lane.js#L151)
- [Card refers to the default export of './Card'](https://github.com/rcdexta/react-trello/blob/master/src/components/Lane.js#L11)
- [Card does not declare `moveCard` as a propType](https://github.com/rcdexta/react-trello/blob/master/src/components/Card.js#L89)
- [The only reference in this project to `moveCard` is in Lane.js](https://github.com/rcdexta/react-trello/search?utf8=%E2%9C%93&q=moveCard&type=)
- The only places where the `moveCard` prop could leak down to children of Card are:
  1. [passed down to MovableCardWrapper](https://github.com/rcdexta/react-trello/blob/master/src/components/Card.js#L69) but this is only a `styled` component
  2. [passed down to the element in Card's `customCard` prop](https://github.com/rcdexta/react-trello/blob/master/src/components/Card.js#L25)

Unless someone is depending on `moveCard` being passed to their `customCard` prop, removing this code should have no effect. The call chain is a bit confusing but I think that the `customCard` prop is equal to the `children` prop of the top-level <Board/> component OR a `children` prop in a [lane's reducer data](https://github.com/rcdexta/react-trello/blob/master/src/components/BoardContainer.js#L98).