### PR TITLE
Option to determine if lane should paginate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-trello",
   "description": "Pluggable components to add a trello like kanban board to your application",
+  "version": "1.29.0",
   "main": "dist/index.js",
   "jsnext:main": "components/index.js",
   "module": "components/index.js",

--- a/src/components/BoardContainer.js
+++ b/src/components/BoardContainer.js
@@ -94,7 +94,8 @@ class BoardContainer extends Component {
       'newCardTemplate',
       'customLaneHeader',
       'tagStyle',
-      'children'
+      'children',
+      'shouldLanePaginate'
     ])
 
     return (
@@ -142,7 +143,8 @@ BoardContainer.propTypes = {
   newCardTemplate: PropTypes.node,
   customLaneHeader: PropTypes.element,
   style: PropTypes.object,
-  tagStyle: PropTypes.object
+  tagStyle: PropTypes.object,
+  shouldLanePaginate: PropTypes.func
 }
 
 BoardContainer.defaultProps = {

--- a/src/components/Lane.js
+++ b/src/components/Lane.js
@@ -26,15 +26,14 @@ class Lane extends Component {
     const node = evt.target
     const elemScrolPosition = node.scrollHeight - node.scrollTop - node.clientHeight
     const {onLaneScroll, shouldLanePaginate, id} = this.props
-    const {currentPage} = this.state
+    const {currentPage, loading} = this.state
     const nextPage = currentPage + 1
 
-    // shouldLanePaginate will determine the triggering of onLaneScroll
-    if (!shouldLanePaginate(nextProps, id)) {
-      return
-    }
-
-    if (elemScrolPosition <= 0 && onLaneScroll && !this.state.loading) {
+    if (elemScrolPosition <= 0 && onLaneScroll && !loading) {
+      // shouldLanePaginate will determine the triggering of onLaneScroll
+      if (!shouldLanePaginate(nextPage, id)) {
+        return
+      }
       this.setState({loading: true})
       onLaneScroll(nextPage, id).then(moreCards => {
         if (!moreCards || moreCards.length === 0) {

--- a/src/components/Lane.js
+++ b/src/components/Lane.js
@@ -9,15 +9,7 @@ import uuidv1 from 'uuid/v1'
 import Loader from './Loader'
 import Card from './Card'
 import NewCard from './NewCard'
-import {
-  AddCardLink,
-  LaneFooter,
-  LaneHeader,
-  RightContent,
-  ScrollableLane,
-  Section,
-  Title
-} from '../styles/Base'
+import {AddCardLink, LaneFooter, LaneHeader, RightContent, ScrollableLane, Section, Title} from '../styles/Base'
 
 import * as laneActions from '../actions/LaneActions'
 import {CollapseBtn, ExpandBtn} from '../styles/Elements'
@@ -34,15 +26,15 @@ class Lane extends Component {
     const node = evt.target
     const elemScrolPosition = node.scrollHeight - node.scrollTop - node.clientHeight
     const {onLaneScroll, shouldLanePaginate, id} = this.props
-    const {currentPage} = this.state;      
+    const {currentPage} = this.state
     const nextPage = currentPage + 1
 
     // shouldLanePaginate will determine the triggering of onLaneScroll
-    if(!shouldLanePaginate(nextProps, id)){
+    if (!shouldLanePaginate(nextProps, id)) {
       return
     }
 
-    if (elemScrolPosition <= 0 && onLaneScroll && !this.state.loading) {      
+    if (elemScrolPosition <= 0 && onLaneScroll && !this.state.loading) {
       this.setState({loading: true})
       onLaneScroll(nextPage, id).then(moreCards => {
         if (!moreCards || moreCards.length === 0) {
@@ -177,9 +169,7 @@ class Lane extends Component {
       const {title, label, titleStyle, labelStyle} = this.props
       return (
         <LaneHeader onDoubleClick={this.toggleLaneCollapsed}>
-          <Title style={titleStyle}>
-            {title}
-          </Title>
+          <Title style={titleStyle}>{title}</Title>
           {label && (
             <RightContent>
               <span style={labelStyle}>{label}</span>
@@ -194,9 +184,7 @@ class Lane extends Component {
     const {collapsibleLanes, cards} = this.props
     const {collapsed} = this.state
     if (collapsibleLanes && cards.length > 0) {
-        return <LaneFooter onClick={this.toggleLaneCollapsed}>
-          {collapsed ? <ExpandBtn/> : <CollapseBtn/>}
-        </LaneFooter>
+      return <LaneFooter onClick={this.toggleLaneCollapsed}>{collapsed ? <ExpandBtn /> : <CollapseBtn />}</LaneFooter>
     }
   }
 

--- a/src/components/Lane.js
+++ b/src/components/Lane.js
@@ -33,12 +33,18 @@ class Lane extends Component {
   handleScroll = evt => {
     const node = evt.target
     const elemScrolPosition = node.scrollHeight - node.scrollTop - node.clientHeight
-    const {onLaneScroll} = this.props
-    if (elemScrolPosition <= 0 && onLaneScroll && !this.state.loading) {
-      const {currentPage} = this.state
+    const {onLaneScroll, shouldLanePaginate, id} = this.props
+    const {currentPage} = this.state;      
+    const nextPage = currentPage + 1
+
+    // shouldLanePaginate will determine the triggering of onLaneScroll
+    if(!shouldLanePaginate(nextProps, id)){
+      return
+    }
+
+    if (elemScrolPosition <= 0 && onLaneScroll && !this.state.loading) {      
       this.setState({loading: true})
-      const nextPage = currentPage + 1
-      onLaneScroll(nextPage, this.props.id).then(moreCards => {
+      onLaneScroll(nextPage, id).then(moreCards => {
         if (!moreCards || moreCards.length === 0) {
           // if no cards present, stop retrying until user action
           node.scrollTop = node.scrollTop - 100
@@ -258,7 +264,8 @@ Lane.propTypes = {
   onLaneClick: PropTypes.func,
   newCardTemplate: PropTypes.node,
   addCardLink: PropTypes.node,
-  editable: PropTypes.bool
+  editable: PropTypes.bool,
+  shouldLanePaginate: PropTypes.func
 }
 
 Lane.defaultProps = {
@@ -267,7 +274,8 @@ Lane.defaultProps = {
   labelStyle: {},
   label: undefined,
   editable: false,
-  onCardAdd: () => {}
+  onCardAdd: () => {},
+  shouldLanePaginate: () => true
 }
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
The developer should have the ability to prevent the pagination of a lane. The loading animation causes a small UI jitter with the lane scroll bar on short screens and it would be nice to prevent that from happening. If shouldLanePaginate returns false, onLaneScroll will not be called. 

I'm open to other ideas but figured I would get the conversation going.