### PR TITLE
Removed redux logger

### DIFF
--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -3,10 +3,7 @@ import BoardContainer from './BoardContainer'
 import {Provider} from 'react-redux'
 import {createStore, applyMiddleware} from 'redux'
 import boardReducer from '../reducers/BoardReducer'
-import logger from 'redux-logger'
 import uuidv1 from "uuid/v1"
-
-const middlewares = process.env.NODE_ENV === 'development' ? [logger] : []
 
 export default class Board extends Component {
   constructor() {


### PR DESCRIPTION
A logger is not ever necessary by a module but by the developers application, as a developer I should be able to opt out your logger even in development.