### PR TITLE
fix: Change order of properties in spread object in `addLane` helper function

### DIFF
--- a/src/helpers/LaneHelper.js
+++ b/src/helpers/LaneHelper.js
@@ -42,7 +42,7 @@ const LaneHelper = {
   },
 
   addLane: (state, lane) => {
-    const newLane = {...lane, id: uuidv1(), cards: []}
+    const newLane = {id: uuidv1(), cards: [], ...lane}
     return update(state, {lanes: {$push: [newLane]}})
   },
 


### PR DESCRIPTION
Changed the order of properties in object so that spread is done last.

It makes sense to provide default values for required properties, but by having spread last it allows *all* properties to be provided by the developer if they desire.

This is a bug fix, fixing #120.