### PR TITLE
fix: Change order of properties in spread object in `addNewCard` method property

### DIFF
--- a/src/components/Lane.js
+++ b/src/components/Lane.js
@@ -93,7 +93,7 @@ class Lane extends Component {
     const laneId = this.props.id
     const id = uuidv1()
     this.hideEditableCard()
-    let card = {...params, id}
+    let card = {id, ...params}
     this.props.actions.addCard({laneId, card})
     this.props.onCardAdd(card, laneId)
   }


### PR DESCRIPTION
Changed the order of properties in object so that spread is done last.

It makes sense to provide default values for required properties, but by having spread last it allows *all* properties to be provided by the developer if they desire.

This is a bug fix, fixing #117 

@CodyFitzpatrick this should do it for you 😉 