### PR TITLE
Support `canAddLanes` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This is the container component that encapsulates the lanes and cards
 | cardDraggable       | boolean  | Set to false to disable card dragging. Default: true                                                                           |
 | collapsibleLanes    | boolean  | Make the lanes with cards collapsible. Default: false                                                                          |
 | editable            | boolean  | Makes the entire board editable. Allow cards to be added or deleted Default: false                                             |
+| canAddLanes         | boolean  | Allows new lanes to be added to the board.                          Default: false                                             |
 | handleDragStart     | function | Callback function triggered when card drag is started: `handleDragStart(cardId, laneId)`                                       |
 | handleDragEnd       | function | Callback function triggered when card drag ends: `handleDragEnd(cardId, sourceLaneId, targetLaneId, position, cardDetails)`                 |
 | handleLaneDragStart | function | Callback function triggered when lane drag is started: `handleLaneDragStart(laneId)`                                           |

--- a/src/components/BoardContainer.js
+++ b/src/components/BoardContainer.js
@@ -114,7 +114,7 @@ class BoardContainer extends Component {
   }
 
   render() {
-    const {id, reducerData, draggable, laneDraggable, laneDragClass, style, addLaneTitle, editable, ...otherProps} = this.props
+    const {id, reducerData, draggable, laneDraggable, laneDragClass, style, addLaneTitle, editable, canAddLanes, ...otherProps} = this.props
     const {addLaneMode} = this.state
     // Stick to whitelisting attributes to segregate board and lane props
     const passthroughProps = pick(this.props, [
@@ -129,6 +129,7 @@ class BoardContainer extends Component {
       'cardDraggable',
       'collapsibleLanes',
       'editable',
+      'canAddLanes',
       'hideCardDeleteIcon',
       'customCardLayout',
       'customLaneHeader',
@@ -174,15 +175,18 @@ class BoardContainer extends Component {
             );
           })}
         </Container>
-        <Container
-          orientation="horizontal"
-        >
-          {editable && !addLaneMode ? (
-            <LaneSection style={{width: 200}}>
-              <NewLaneButton onClick={this.showEditableLane}>{addLaneTitle}</NewLaneButton>
-            </LaneSection>
-          ) : (addLaneMode && this.renderNewLane())}
-        </Container>
+        {
+          canAddLanes &&
+          <Container
+            orientation="horizontal"
+          >
+            {editable && !addLaneMode ? (
+              <LaneSection style={{ width: 200 }}>
+                <NewLaneButton onClick={this.showEditableLane}>{addLaneTitle}</NewLaneButton>
+              </LaneSection>
+            ) : (addLaneMode && this.renderNewLane())}
+          </Container>
+        }
       </BoardDiv>
     );
   }
@@ -205,6 +209,7 @@ BoardContainer.propTypes = {
   draggable: PropTypes.bool,
   collapsibleLanes: PropTypes.bool,
   editable: PropTypes.bool,
+  canAddLanes: PropTypes.bool,
   hideCardDeleteIcon: PropTypes.bool,
   handleDragStart: PropTypes.func,
   handleDragEnd: PropTypes.func,
@@ -230,6 +235,7 @@ BoardContainer.defaultProps = {
   handleLaneDragStart: () => {},
   handleLaneDragEnd: () => {},
   editable: false,
+  canAddLanes: false,
   hideCardDeleteIcon: false,
   draggable: false,
   collapsibleLanes: false,


### PR DESCRIPTION
Adds a prop to `BoardContainer` allowing you to control if lanes can be added to the board.

Fixes #128 