### PR TITLE
Fixing 'canAddLanes' being ignored

### DIFF
--- a/src/components/BoardContainer.js
+++ b/src/components/BoardContainer.js
@@ -118,6 +118,7 @@ class BoardContainer extends Component {
 
   render() {
     const {id, reducerData, draggable, laneDraggable, laneDragClass, style, onDataChange, onLaneScroll, onCardClick, onLaneClick, onCardDelete, onCardAdd, addLaneTitle, editable, canAddLanes, ...otherProps} = this.props
+    const {addLaneMode} = this.state
     // Stick to whitelisting attributes to segregate board and lane props
     const passthroughProps = pick(this.props, [
       'onLaneScroll',
@@ -174,6 +175,17 @@ class BoardContainer extends Component {
             return draggable && laneDraggable ? <Draggable key={lane.id}>{laneToRender}</Draggable> : <span key={lane.id}>{laneToRender}</span>
           })}
         </Container>
+        {canAddLanes && (
+          <Container orientation="horizontal">
+            {editable && !addLaneMode ? (
+              <LaneSection style={{width: 200}}>
+                <NewLaneButton onClick={this.showEditableLane}>{addLaneTitle}</NewLaneButton>
+              </LaneSection>
+            ) : (
+              addLaneMode && this.renderNewLane()
+            )}
+          </Container>
+        )}
       </BoardDiv>
     )
   }


### PR DESCRIPTION
I only reverted the chnages, as pointed out in these issues:

https://github.com/rcdexta/react-trello/issues/180
https://github.com/rcdexta/react-trello/issues/173

By the way, is there a `onLaneAdd` event?