### PR TITLE
Remove duplicated editLaneTitle propType

### DIFF
--- a/src/components/Lane/LaneHeader.js
+++ b/src/components/Lane/LaneHeader.js
@@ -35,7 +35,6 @@ LaneHeaderComponent.propTypes = {
   title: PropTypes.string,
   onDelete: PropTypes.func,
   onDoubleClick: PropTypes.func,
-  editLaneTitle: PropTypes.bool,
   t: PropTypes.func.isRequired
 }
 


### PR DESCRIPTION
LaneHeaderComponent specified two editLaneTitle props, causing a warning to be shown