### PR TITLE
Fix `module` path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "react-trello",
   "description": "Pluggable components to add a trello like kanban board to your application",
   "main": "dist/index.js",
-  "jsnext:main": "components/index.js",
-  "module": "components/index.js",
+  "jsnext:main": "src/components/index.js",
+  "module": "src/components/index.js",
   "files": [
     "src",
     "dist",


### PR DESCRIPTION
The current value of `"module": "components/index.js"` comes from the initial commit from 3 years ago and was never updated when `components` were moved into `src` at some point. This incorrect value doesn't cause any real problem per se in practice however it does have the annoying effect of causing certain IDEs (i.e. WebStorm) to flag `react-trello` import statement with a "Module not installed" warning message. The warning message itself also doesn't cause any problem within the IDE other than annoyance, but I would like to not be annoyed, hence this commit to fix the path.

--

Side note: I don't know what that `jsnext:main`'s purpose is but in any case its value also isn't a valid path so I updated it at the same time.