### PR TITLE
Adding UPDATE_CARDS to the EventBus

### DIFF
--- a/src/controllers/BoardContainer.js
+++ b/src/controllers/BoardContainer.js
@@ -74,6 +74,8 @@ class BoardContainer extends Component {
               cardId: event.cardId,
               index: event.index
             })
+          case 'UPDATE_CARDS':
+          return actions.updateCards({laneId: event.laneId, cards: event.cards})
           case 'UPDATE_LANES':
             return actions.updateLanes(event.lanes)
           case 'UPDATE_LANE':


### PR DESCRIPTION
Hey,
I am currently developing a realtime Kanban board by using your trello board combined with socket.io.
Most recently I tried to implement a search function to filter all the tickets on the board. I tried several approaches and the best one was to make the UPDATE_CARDS function to the EventBus and adding `style:{display: 'none'}` to all the tickets which do not match the search pattern.

I am really interested why this action is not available by default. Maybe you have a better solution for this problem or did you already think about implementing such a function?