### PR TITLE
Prevent Lane re-renders onDragEnd

### DIFF
--- a/src/controllers/Lane.js
+++ b/src/controllers/Lane.js
@@ -113,7 +113,11 @@ class Lane extends Component {
   onDragEnd = (laneId, result) => {
     const {handleDragEnd} = this.props
     const {addedIndex, payload} = result
-    this.setState({isDraggingOver: false})
+
+    if (this.state.isDraggingOver) {
+      this.setState({isDraggingOver: false})
+    }
+
     if (addedIndex != null) {
       const newCard = {...cloneDeep(payload), laneId}
       const response = handleDragEnd ? handleDragEnd(payload.id, payload.laneId, laneId, addedIndex, newCard) : true


### PR DESCRIPTION
Our react-trello boards contains around 250 cards, which would cause performance problems.  One of the problem seemed to come from a Lane which we almost never interact with when dragging cards, which contained most of the cards.

With some investigation with the React DevTool, I was able to find out that the onDragEnd updated the state even when not necessary, which caused a re-render of all Lanes present in the Board.

Looking at the React documentation,  I found out that calling this.setState causes a re-render even if the state has not changed.  This can be prevented with componentShouldUpdate or not causing the state change in the first place.

The reason why it's in the 2.1 branch is because we have other performance problems with the most recent version.