### PR TITLE
Sort cards before state update

### DIFF
--- a/src/controllers/Lane.js
+++ b/src/controllers/Lane.js
@@ -110,7 +110,7 @@ class Lane extends Component {
     return `TrelloBoard${boardId}Lane`
   }
 
-  onDragEnd = (laneId, result) => {
+  onDragEnd = (laneId, result, laneSortFunction) => {
     const {handleDragEnd} = this.props
     const {addedIndex, payload} = result
     this.setState({isDraggingOver: false})
@@ -122,7 +122,8 @@ class Lane extends Component {
           fromLaneId: payload.laneId,
           toLaneId: laneId,
           cardId: payload.id,
-          index: addedIndex
+          index: addedIndex,
+          laneSortFunction
         })
         this.props.onCardMoveAcrossLanes(payload.laneId, laneId, payload.id, addedIndex)
       }
@@ -178,7 +179,7 @@ class Lane extends Component {
           groupName={this.groupName}
           dragClass={cardDragClass}
           onDragStart={this.onDragStart}
-          onDrop={e => this.onDragEnd(id, e)}
+          onDrop={e => this.onDragEnd(id, e, laneSortFunction)}
           onDragEnter={() => this.setState({isDraggingOver: true})}
           onDragLeave={() => this.setState({isDraggingOver: false})}
           shouldAcceptDrop={this.shouldAcceptDrop}
@@ -204,7 +205,7 @@ class Lane extends Component {
     this.props.onLaneUpdate(this.props.id, {title: value})
   }
 
-  renderHeader = (pickedProps) => {
+  renderHeader = pickedProps => {
     const {components} = this.props
     return (
       <components.LaneHeader

--- a/src/helpers/LaneHelper.js
+++ b/src/helpers/LaneHelper.js
@@ -29,7 +29,7 @@ const LaneHelper = {
           let cardsToUpdate = [...lane.cards, ...newCards]
 
           if (laneSortFunction) {
-            cardsToUpdate.sort(function(card1, card2) {
+            cardsToUpdate.sort(laneSortFunction)
               return laneSortFunction(card1, card2)
             })
           }

--- a/src/helpers/LaneHelper.js
+++ b/src/helpers/LaneHelper.js
@@ -30,8 +30,6 @@ const LaneHelper = {
 
           if (laneSortFunction) {
             cardsToUpdate.sort(laneSortFunction)
-              return laneSortFunction(card1, card2)
-            })
           }
 
           return update(lane, {cards: {$set: cardsToUpdate}})

--- a/src/helpers/LaneHelper.js
+++ b/src/helpers/LaneHelper.js
@@ -17,15 +17,24 @@ const LaneHelper = {
     return update(state, {lanes: {$set: updatedLanes}})
   },
 
-  appendCardsToLane: (state, {laneId, newCards, index}) => {
+  appendCardsToLane: (state, {laneId, newCards, index}, laneSortFunction) => {
     const lane = state.lanes.find(lane => lane.id === laneId)
     newCards = newCards
       .map(c => update(c, {laneId: {$set: laneId}}))
       .filter(c => lane.cards.find(card => card.id === c.id) == null)
+
     return state.lanes.map(lane => {
       if (lane.id === laneId) {
         if (index !== undefined) {
-          return update(lane, {cards: {$splice: [[index, 0, ...newCards]]}})
+          let cardsToUpdate = [...lane.cards, ...newCards]
+
+          if (laneSortFunction) {
+            cardsToUpdate.sort(function(card1, card2) {
+              return laneSortFunction(card1, card2)
+            })
+          }
+
+          return update(lane, {cards: {$set: cardsToUpdate}})
         } else {
           const cardsToUpdate = [...lane.cards, ...newCards]
           return update(lane, {cards: {$set: cardsToUpdate}})
@@ -36,8 +45,8 @@ const LaneHelper = {
     })
   },
 
-  appendCardToLane: (state, {laneId, card, index}) => {
-    const newLanes = LaneHelper.appendCardsToLane(state, {laneId: laneId, newCards: [card], index})
+  appendCardToLane: (state, {laneId, card, index}, laneSortFunction) => {
+    const newLanes = LaneHelper.appendCardsToLane(state, {laneId: laneId, newCards: [card], index}, laneSortFunction)
     return update(state, {lanes: {$set: newLanes}})
   },
 
@@ -48,8 +57,8 @@ const LaneHelper = {
 
   updateLane: (state, updatedLane) => {
     const newLanes = state.lanes.map(lane => {
-      if (updatedLane.id == lane.id ) {
-        return { ...lane, ...updatedLane }
+      if (updatedLane.id == lane.id) {
+        return {...lane, ...updatedLane}
       } else {
         return lane
       }
@@ -69,7 +78,7 @@ const LaneHelper = {
     return update(state, {lanes: {$set: lanes}})
   },
 
-  moveCardAcrossLanes: (state, {fromLaneId, toLaneId, cardId, index}) => {
+  moveCardAcrossLanes: (state, {fromLaneId, toLaneId, cardId, index, laneSortFunction}) => {
     let cardToMove = null
     const interimLanes = state.lanes.map(lane => {
       if (lane.id === fromLaneId) {
@@ -81,7 +90,11 @@ const LaneHelper = {
       }
     })
     const updatedState = update(state, {lanes: {$set: interimLanes}})
-    return LaneHelper.appendCardToLane(updatedState, {laneId: toLaneId, card: cardToMove, index: index})
+    return LaneHelper.appendCardToLane(
+      updatedState,
+      {laneId: toLaneId, card: cardToMove, index: index},
+      laneSortFunction
+    )
   },
 
   updateCardsForLane: (state, {laneId, cards}) => {
@@ -101,7 +114,7 @@ const LaneHelper = {
 
   moveLane: (state, {oldIndex, newIndex}) => {
     const laneToMove = state.lanes[oldIndex]
-    const tempState = update(state, {lanes: {$splice: [[oldIndex, 1]]}});
+    const tempState = update(state, {lanes: {$splice: [[oldIndex, 1]]}})
     return update(tempState, {lanes: {$splice: [[newIndex, 0, laneToMove]]}})
   },
 

--- a/stories/Sort.story.js
+++ b/stories/Sort.story.js
@@ -17,7 +17,7 @@ function compare(a, b) {
 }
 
 storiesOf('Basic Functions', module)
-  .add('Sorted Lane', () => <Board data={data} laneSortFunction={(card1, card2) => compare(card1, card2)} />, {
+  .add('Sorted Lane', () => <Board data={data} laneSortFunction={compare} />, {
     info: 'A lane sorted by completed at ascending'
   })
   .add(

--- a/stories/Sort.story.js
+++ b/stories/Sort.story.js
@@ -5,14 +5,28 @@ import Board from '../src'
 
 const data = require('./data/data-sort.json')
 
+function compare(a, b) {
+  if (a.title > b.title) {
+    return 1
+  }
+  if (a.title < b.title) {
+    return -1
+  }
+
+  return 0
+}
+
 storiesOf('Basic Functions', module)
-  .add(
-    'Sorted Lane',
-    () => <Board data={data} laneSortFunction={(card1, card2) => new Date(card1.metadata.completedAt) - new Date(card2.metadata.completedAt)} />,
-    {info: 'A lane sorted by completed at ascending'}
-  )
+  .add('Sorted Lane', () => <Board data={data} laneSortFunction={(card1, card2) => compare(card1, card2)} />, {
+    info: 'A lane sorted by completed at ascending'
+  })
   .add(
     'Reverse Sorted Lane',
-    () => <Board data={data} laneSortFunction={(card1, card2) => new Date(card2.metadata.completedAt) - new Date(card1.metadata.completedAt)} />,
+    () => (
+      <Board
+        data={data}
+        laneSortFunction={(card1, card2) => new Date(card2.metadata.completedAt) - new Date(card1.metadata.completedAt)}
+      />
+    ),
     {info: 'A lane sorted by completed at descending'}
   )

--- a/stories/data/data-sort.json
+++ b/stories/data/data-sort.json
@@ -47,6 +47,20 @@
           }
         }
       ]
+    },
+    {
+      "id": "WIP",
+      "title": "Work In Progress",
+      "label": "10/20",
+      "style": {"width": 280},
+      "cards": [
+        {
+          "id": "Wip1",
+          "title": "Clean House",
+          "label": "30 mins",
+          "description": "Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses"
+        }
+      ]
     }
   ]
 }

--- a/tests/__snapshots__/Storyshots.test.js.snap
+++ b/tests/__snapshots__/Storyshots.test.js.snap
@@ -10325,6 +10325,24 @@ exports[`Storyshots Basic Functions Reverse Sorted Lane 1`] = `
               "label": "20/70",
               "title": "Sorted Lane",
             },
+            Object {
+              "cards": Array [
+                Object {
+                  "description": "Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses",
+                  "id": "Wip1",
+                  "label": "30 mins",
+                  "laneId": "WIP",
+                  "title": "Clean House",
+                },
+              ],
+              "currentPage": 1,
+              "id": "WIP",
+              "label": "10/20",
+              "style": Object {
+                "width": 280,
+              },
+              "title": "Work In Progress",
+            },
           ],
         }
       }
@@ -10529,6 +10547,87 @@ exports[`Storyshots Basic Functions Reverse Sorted Lane 1`] = `
                       className="c13"
                     >
                       Transfer to bank account
+                    </div>
+                  </article>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section
+            className="react-trello-lane c1"
+            draggable={false}
+            label="10/20"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": 280,
+              }
+            }
+            title="Work In Progress"
+          >
+            <header
+              className="c2"
+              onDoubleClick={[Function]}
+            >
+              <span
+                className="c3"
+                draggable={true}
+                style={Object {}}
+              >
+                Work In Progress
+              </span>
+              <span
+                className="c4"
+              >
+                <span
+                  style={Object {}}
+                >
+                  10/20
+                </span>
+              </span>
+            </header>
+            <div
+              className="c5"
+            >
+              <div>
+                <div
+                  className="smooth-dnd-draggable-wrapper"
+                >
+                  <article
+                    className="react-trello-card c6 c7"
+                    data-id="Wip1"
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    <header
+                      className="c8"
+                    >
+                      <span
+                        className="c9"
+                        draggable={true}
+                      >
+                        Clean House
+                      </span>
+                      <span
+                        className="c10"
+                      >
+                        30 mins
+                      </span>
+                      <div
+                        className="c11"
+                        onClick={[Function]}
+                      >
+                        <button
+                          className="c12"
+                        >
+                          ✖
+                        </button>
+                      </div>
+                    </header>
+                    <div
+                      className="c13"
+                    >
+                      Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses
                     </div>
                   </article>
                 </div>
@@ -10839,6 +10938,115 @@ exports[`Storyshots Basic Functions Reverse Sorted Lane 1`] = `
                                   }
                                 >
                                   '20/70'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                        
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'WIP'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    title
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Work In Progress'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    label
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  '10/20'
                                 </span>
                                 ,
                                 <span>
@@ -11179,6 +11387,24 @@ exports[`Storyshots Basic Functions Sorted Lane 1`] = `
               "label": "20/70",
               "title": "Sorted Lane",
             },
+            Object {
+              "cards": Array [
+                Object {
+                  "description": "Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses",
+                  "id": "Wip1",
+                  "label": "30 mins",
+                  "laneId": "WIP",
+                  "title": "Clean House",
+                },
+              ],
+              "currentPage": 1,
+              "id": "WIP",
+              "label": "10/20",
+              "style": Object {
+                "width": 280,
+              },
+              "title": "Work In Progress",
+            },
           ],
         }
       }
@@ -11222,6 +11448,88 @@ exports[`Storyshots Basic Functions Sorted Lane 1`] = `
               className="c5"
             >
               <div>
+                <div
+                  className="smooth-dnd-draggable-wrapper"
+                >
+                  <article
+                    className="react-trello-card c6 c7"
+                    data-id="Card1"
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    <header
+                      className="c8"
+                    >
+                      <span
+                        className="c9"
+                        draggable={true}
+                      >
+                        Buy milk
+                      </span>
+                      <span
+                        className="c10"
+                      >
+                        2017-12-01
+                      </span>
+                      <div
+                        className="c11"
+                        onClick={[Function]}
+                      >
+                        <button
+                          className="c12"
+                        >
+                          ✖
+                        </button>
+                      </div>
+                    </header>
+                    <div
+                      className="c13"
+                    >
+                      2 Gallons of milk at the Deli store
+                    </div>
+                  </article>
+                </div>
+                <div
+                  className="smooth-dnd-draggable-wrapper"
+                >
+                  <article
+                    className="react-trello-card c6 c7"
+                    data-id="Card2"
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    <header
+                      className="c8"
+                    >
+                      <span
+                        className="c9"
+                        draggable={true}
+                      >
+                        Dispose Garbage
+                      </span>
+                      <span
+                        className="c10"
+                      >
+                        2017-11-01
+                      </span>
+                      <div
+                        className="c11"
+                        onClick={[Function]}
+                      >
+                        <button
+                          className="c12"
+                        >
+                          ✖
+                        </button>
+                      </div>
+                    </header>
+                    <div
+                      className="c13"
+                    >
+                      Sort out recyclable and waste as needed
+                    </div>
+                  </article>
+                </div>
                 <div
                   className="smooth-dnd-draggable-wrapper"
                 >
@@ -11304,12 +11612,52 @@ exports[`Storyshots Basic Functions Sorted Lane 1`] = `
                     </div>
                   </article>
                 </div>
+              </div>
+            </div>
+          </section>
+          <section
+            className="react-trello-lane c1"
+            draggable={false}
+            label="10/20"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": 280,
+              }
+            }
+            title="Work In Progress"
+          >
+            <header
+              className="c2"
+              onDoubleClick={[Function]}
+            >
+              <span
+                className="c3"
+                draggable={true}
+                style={Object {}}
+              >
+                Work In Progress
+              </span>
+              <span
+                className="c4"
+              >
+                <span
+                  style={Object {}}
+                >
+                  10/20
+                </span>
+              </span>
+            </header>
+            <div
+              className="c5"
+            >
+              <div>
                 <div
                   className="smooth-dnd-draggable-wrapper"
                 >
                   <article
                     className="react-trello-card c6 c7"
-                    data-id="Card2"
+                    data-id="Wip1"
                     onClick={[Function]}
                     style={Object {}}
                   >
@@ -11320,12 +11668,12 @@ exports[`Storyshots Basic Functions Sorted Lane 1`] = `
                         className="c9"
                         draggable={true}
                       >
-                        Dispose Garbage
+                        Clean House
                       </span>
                       <span
                         className="c10"
                       >
-                        2017-11-01
+                        30 mins
                       </span>
                       <div
                         className="c11"
@@ -11341,48 +11689,7 @@ exports[`Storyshots Basic Functions Sorted Lane 1`] = `
                     <div
                       className="c13"
                     >
-                      Sort out recyclable and waste as needed
-                    </div>
-                  </article>
-                </div>
-                <div
-                  className="smooth-dnd-draggable-wrapper"
-                >
-                  <article
-                    className="react-trello-card c6 c7"
-                    data-id="Card1"
-                    onClick={[Function]}
-                    style={Object {}}
-                  >
-                    <header
-                      className="c8"
-                    >
-                      <span
-                        className="c9"
-                        draggable={true}
-                      >
-                        Buy milk
-                      </span>
-                      <span
-                        className="c10"
-                      >
-                        2017-12-01
-                      </span>
-                      <div
-                        className="c11"
-                        onClick={[Function]}
-                      >
-                        <button
-                          className="c12"
-                        >
-                          ✖
-                        </button>
-                      </div>
-                    </header>
-                    <div
-                      className="c13"
-                    >
-                      2 Gallons of milk at the Deli store
+                      Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses
                     </div>
                   </article>
                 </div>
@@ -11693,6 +12000,115 @@ exports[`Storyshots Basic Functions Sorted Lane 1`] = `
                                   }
                                 >
                                   '20/70'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                        
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'WIP'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    title
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Work In Progress'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    label
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  '10/20'
                                 </span>
                                 ,
                                 <span>
@@ -21963,6 +22379,24 @@ exports[`Storyshots Custom Components NewLaneForm 1`] = `
               "label": "20/70",
               "title": "Sorted Lane",
             },
+            Object {
+              "cards": Array [
+                Object {
+                  "description": "Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses",
+                  "id": "Wip1",
+                  "label": "30 mins",
+                  "laneId": "WIP",
+                  "title": "Clean House",
+                },
+              ],
+              "currentPage": 1,
+              "id": "WIP",
+              "label": "10/20",
+              "style": Object {
+                "width": 280,
+              },
+              "title": "Work In Progress",
+            },
           ],
         }
       }
@@ -22214,6 +22648,140 @@ exports[`Storyshots Custom Components NewLaneForm 1`] = `
                       className="c22"
                     >
                       Transfer to bank account
+                    </div>
+                  </article>
+                </div>
+              </div>
+              <a
+                className="c23"
+                onClick={[Function]}
+              >
+                Click to add card
+              </a>
+            </div>
+          </section>
+          <section
+            className="react-trello-lane c1"
+            draggable={false}
+            label="10/20"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": 280,
+              }
+            }
+            title="Work In Progress"
+          >
+            <header
+              className="c2"
+              onDoubleClick={[Function]}
+            >
+              <span
+                className="c3"
+                draggable={true}
+                style={Object {}}
+              >
+                Work In Progress
+              </span>
+              <span
+                className="c4"
+              >
+                <span
+                  style={Object {}}
+                >
+                  10/20
+                </span>
+              </span>
+              <div
+                className="c5"
+              >
+                <a
+                  className="fePDys"
+                  href=""
+                  onClick={[Function]}
+                >
+                  <button
+                    className="c6"
+                  >
+                    ⋮
+                  </button>
+                </a>
+                <div
+                  className="c7 c8"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <span
+                      className="c10"
+                    >
+                      Lane actions
+                    </span>
+                    <div
+                      className="c11"
+                    >
+                      <button
+                        className="c12"
+                      >
+                        ✖
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="c13"
+                  >
+                    <div
+                      className="c14"
+                      onClick={[Function]}
+                    >
+                      Delete lane
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </header>
+            <div
+              className="c15"
+            >
+              <div>
+                <div
+                  className="smooth-dnd-draggable-wrapper"
+                >
+                  <article
+                    className="react-trello-card c16 c17"
+                    data-id="Wip1"
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    <header
+                      className="c18"
+                    >
+                      <span
+                        className="c19"
+                        draggable={true}
+                      >
+                        Clean House
+                      </span>
+                      <span
+                        className="c20"
+                      >
+                        30 mins
+                      </span>
+                      <div
+                        className="c11"
+                        onClick={[Function]}
+                      >
+                        <button
+                          className="c21"
+                        >
+                          ✖
+                        </button>
+                      </div>
+                    </header>
+                    <div
+                      className="c22"
+                    >
+                      Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses
                     </div>
                   </article>
                 </div>
@@ -22599,6 +23167,115 @@ exports[`Storyshots Custom Components NewLaneForm 1`] = `
                                   }
                                 >
                                   '20/70'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                        
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'WIP'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    title
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Work In Progress'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    label
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  '10/20'
                                 </span>
                                 ,
                                 <span>
@@ -23105,6 +23782,24 @@ exports[`Storyshots Custom Components NewLaneSection 1`] = `
               "label": "20/70",
               "title": "Sorted Lane",
             },
+            Object {
+              "cards": Array [
+                Object {
+                  "description": "Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses",
+                  "id": "Wip1",
+                  "label": "30 mins",
+                  "laneId": "WIP",
+                  "title": "Clean House",
+                },
+              ],
+              "currentPage": 1,
+              "id": "WIP",
+              "label": "10/20",
+              "style": Object {
+                "width": 280,
+              },
+              "title": "Work In Progress",
+            },
           ],
         }
       }
@@ -23356,6 +24051,140 @@ exports[`Storyshots Custom Components NewLaneSection 1`] = `
                       className="c22"
                     >
                       Transfer to bank account
+                    </div>
+                  </article>
+                </div>
+              </div>
+              <a
+                className="c23"
+                onClick={[Function]}
+              >
+                Click to add card
+              </a>
+            </div>
+          </section>
+          <section
+            className="react-trello-lane c1"
+            draggable={false}
+            label="10/20"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": 280,
+              }
+            }
+            title="Work In Progress"
+          >
+            <header
+              className="c2"
+              onDoubleClick={[Function]}
+            >
+              <span
+                className="c3"
+                draggable={true}
+                style={Object {}}
+              >
+                Work In Progress
+              </span>
+              <span
+                className="c4"
+              >
+                <span
+                  style={Object {}}
+                >
+                  10/20
+                </span>
+              </span>
+              <div
+                className="c5"
+              >
+                <a
+                  className="fePDys"
+                  href=""
+                  onClick={[Function]}
+                >
+                  <button
+                    className="c6"
+                  >
+                    ⋮
+                  </button>
+                </a>
+                <div
+                  className="c7 c8"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <span
+                      className="c10"
+                    >
+                      Lane actions
+                    </span>
+                    <div
+                      className="c11"
+                    >
+                      <button
+                        className="c12"
+                      >
+                        ✖
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="c13"
+                  >
+                    <div
+                      className="c14"
+                      onClick={[Function]}
+                    >
+                      Delete lane
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </header>
+            <div
+              className="c15"
+            >
+              <div>
+                <div
+                  className="smooth-dnd-draggable-wrapper"
+                >
+                  <article
+                    className="react-trello-card c16 c17"
+                    data-id="Wip1"
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    <header
+                      className="c18"
+                    >
+                      <span
+                        className="c19"
+                        draggable={true}
+                      >
+                        Clean House
+                      </span>
+                      <span
+                        className="c20"
+                      >
+                        30 mins
+                      </span>
+                      <div
+                        className="c11"
+                        onClick={[Function]}
+                      >
+                        <button
+                          className="c21"
+                        >
+                          ✖
+                        </button>
+                      </div>
+                    </header>
+                    <div
+                      className="c22"
+                    >
+                      Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses
                     </div>
                   </article>
                 </div>
@@ -23736,6 +24565,115 @@ exports[`Storyshots Custom Components NewLaneSection 1`] = `
                                   }
                                 >
                                   '20/70'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                        
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'WIP'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    title
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Work In Progress'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    label
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  '10/20'
                                 </span>
                                 ,
                                 <span>
@@ -32521,6 +33459,24 @@ exports[`Storyshots Editable Board Add New Lane 1`] = `
               "label": "20/70",
               "title": "Sorted Lane",
             },
+            Object {
+              "cards": Array [
+                Object {
+                  "description": "Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses",
+                  "id": "Wip1",
+                  "label": "30 mins",
+                  "laneId": "WIP",
+                  "title": "Clean House",
+                },
+              ],
+              "currentPage": 1,
+              "id": "WIP",
+              "label": "10/20",
+              "style": Object {
+                "width": 280,
+              },
+              "title": "Work In Progress",
+            },
           ],
         }
       }
@@ -32772,6 +33728,140 @@ exports[`Storyshots Editable Board Add New Lane 1`] = `
                       className="c22"
                     >
                       Transfer to bank account
+                    </div>
+                  </article>
+                </div>
+              </div>
+              <a
+                className="c23"
+                onClick={[Function]}
+              >
+                Click to add card
+              </a>
+            </div>
+          </section>
+          <section
+            className="react-trello-lane c1"
+            draggable={false}
+            label="10/20"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": 280,
+              }
+            }
+            title="Work In Progress"
+          >
+            <header
+              className="c2"
+              onDoubleClick={[Function]}
+            >
+              <span
+                className="c3"
+                draggable={true}
+                style={Object {}}
+              >
+                Work In Progress
+              </span>
+              <span
+                className="c4"
+              >
+                <span
+                  style={Object {}}
+                >
+                  10/20
+                </span>
+              </span>
+              <div
+                className="c5"
+              >
+                <a
+                  className="fePDys"
+                  href=""
+                  onClick={[Function]}
+                >
+                  <button
+                    className="c6"
+                  >
+                    ⋮
+                  </button>
+                </a>
+                <div
+                  className="c7 c8"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <span
+                      className="c10"
+                    >
+                      Lane actions
+                    </span>
+                    <div
+                      className="c11"
+                    >
+                      <button
+                        className="c12"
+                      >
+                        ✖
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="c13"
+                  >
+                    <div
+                      className="c14"
+                      onClick={[Function]}
+                    >
+                      Delete lane
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </header>
+            <div
+              className="c15"
+            >
+              <div>
+                <div
+                  className="smooth-dnd-draggable-wrapper"
+                >
+                  <article
+                    className="react-trello-card c16 c17"
+                    data-id="Wip1"
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    <header
+                      className="c18"
+                    >
+                      <span
+                        className="c19"
+                        draggable={true}
+                      >
+                        Clean House
+                      </span>
+                      <span
+                        className="c20"
+                      >
+                        30 mins
+                      </span>
+                      <div
+                        className="c11"
+                        onClick={[Function]}
+                      >
+                        <button
+                          className="c21"
+                        >
+                          ✖
+                        </button>
+                      </div>
+                    </header>
+                    <div
+                      className="c22"
+                    >
+                      Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses
                     </div>
                   </article>
                 </div>
@@ -33103,6 +34193,115 @@ exports[`Storyshots Editable Board Add New Lane 1`] = `
                                   }
                                 >
                                   '20/70'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                        
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'WIP'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    title
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Work In Progress'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    label
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  '10/20'
                                 </span>
                                 ,
                                 <span>
@@ -37567,6 +38766,24 @@ exports[`Storyshots Editable Board Inline Edit Lane Title 1`] = `
               "label": "20/70",
               "title": "Sorted Lane",
             },
+            Object {
+              "cards": Array [
+                Object {
+                  "description": "Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses",
+                  "id": "Wip1",
+                  "label": "30 mins",
+                  "laneId": "WIP",
+                  "title": "Clean House",
+                },
+              ],
+              "currentPage": 1,
+              "id": "WIP",
+              "label": "10/20",
+              "style": Object {
+                "width": 280,
+              },
+              "title": "Work In Progress",
+            },
           ],
         }
       }
@@ -37832,6 +39049,154 @@ exports[`Storyshots Editable Board Inline Edit Lane Title 1`] = `
                       className="c23"
                     >
                       Transfer to bank account
+                    </div>
+                  </article>
+                </div>
+              </div>
+              <a
+                className="c24"
+                onClick={[Function]}
+              >
+                Click to add card
+              </a>
+            </div>
+          </section>
+          <section
+            className="react-trello-lane c1"
+            draggable={false}
+            label="10/20"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": 280,
+              }
+            }
+            title="Work In Progress"
+          >
+            <header
+              className="c2"
+              onDoubleClick={[Function]}
+            >
+              <span
+                className="c3"
+                draggable={true}
+                style={Object {}}
+              >
+                <textarea
+                  autoCapitalize="off"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  autoFocus={false}
+                  className="c4"
+                  defaultValue="Work In Progress"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  placeholder="title"
+                  rows={1}
+                  spellCheck="false"
+                />
+              </span>
+              <span
+                className="c5"
+              >
+                <span
+                  style={Object {}}
+                >
+                  10/20
+                </span>
+              </span>
+              <div
+                className="c6"
+              >
+                <a
+                  className="fePDys"
+                  href=""
+                  onClick={[Function]}
+                >
+                  <button
+                    className="c7"
+                  >
+                    ⋮
+                  </button>
+                </a>
+                <div
+                  className="c8 c9"
+                >
+                  <div
+                    className="c10"
+                  >
+                    <span
+                      className="c11"
+                    >
+                      Lane actions
+                    </span>
+                    <div
+                      className="c12"
+                    >
+                      <button
+                        className="c13"
+                      >
+                        ✖
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="c14"
+                  >
+                    <div
+                      className="c15"
+                      onClick={[Function]}
+                    >
+                      Delete lane
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </header>
+            <div
+              className="c16"
+            >
+              <div>
+                <div
+                  className="smooth-dnd-draggable-wrapper"
+                >
+                  <article
+                    className="react-trello-card c17 c18"
+                    data-id="Wip1"
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    <header
+                      className="c19"
+                    >
+                      <span
+                        className="c20"
+                        draggable={true}
+                      >
+                        Clean House
+                      </span>
+                      <span
+                        className="c21"
+                      >
+                        30 mins
+                      </span>
+                      <div
+                        className="c12"
+                        onClick={[Function]}
+                      >
+                        <button
+                          className="c22"
+                        >
+                          ✖
+                        </button>
+                      </div>
+                    </header>
+                    <div
+                      className="c23"
+                    >
+                      Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses
                     </div>
                   </article>
                 </div>
@@ -38163,6 +39528,115 @@ exports[`Storyshots Editable Board Inline Edit Lane Title 1`] = `
                                   }
                                 >
                                   '20/70'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                        
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'WIP'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    title
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Work In Progress'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    label
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  '10/20'
                                 </span>
                                 ,
                                 <span>
@@ -38794,6 +40268,24 @@ exports[`Storyshots I18n Custom texts 1`] = `
               "label": "20/70",
               "title": "Sorted Lane",
             },
+            Object {
+              "cards": Array [
+                Object {
+                  "description": "Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses",
+                  "id": "Wip1",
+                  "label": "30 mins",
+                  "laneId": "WIP",
+                  "title": "Clean House",
+                },
+              ],
+              "currentPage": 1,
+              "id": "WIP",
+              "label": "10/20",
+              "style": Object {
+                "width": 280,
+              },
+              "title": "Work In Progress",
+            },
           ],
         }
       }
@@ -39048,6 +40540,144 @@ exports[`Storyshots I18n Custom texts 1`] = `
                         className="c22"
                       >
                         Transfer to bank account
+                      </div>
+                    </article>
+                  </div>
+                </div>
+                <a
+                  className="c23"
+                  onClick={[Function]}
+                >
+                  Click to add card
+                </a>
+              </div>
+            </section>
+          </div>
+          <div
+            className="smooth-dnd-draggable-wrapper"
+          >
+            <section
+              className="react-trello-lane c1"
+              draggable={false}
+              label="10/20"
+              onClick={[Function]}
+              style={
+                Object {
+                  "width": 280,
+                }
+              }
+              title="Work In Progress"
+            >
+              <header
+                className="c2"
+                onDoubleClick={[Function]}
+              >
+                <span
+                  className="c3"
+                  draggable={true}
+                  style={Object {}}
+                >
+                  Work In Progress
+                </span>
+                <span
+                  className="c4"
+                >
+                  <span
+                    style={Object {}}
+                  >
+                    10/20
+                  </span>
+                </span>
+                <div
+                  className="c5"
+                >
+                  <a
+                    className="fePDys"
+                    href=""
+                    onClick={[Function]}
+                  >
+                    <button
+                      className="c6"
+                    >
+                      ⋮
+                    </button>
+                  </a>
+                  <div
+                    className="c7 c8"
+                  >
+                    <div
+                      className="c9"
+                    >
+                      <span
+                        className="c10"
+                      >
+                        Lane actions
+                      </span>
+                      <div
+                        className="c11"
+                      >
+                        <button
+                          className="c12"
+                        >
+                          ✖
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      className="c13"
+                    >
+                      <div
+                        className="c14"
+                        onClick={[Function]}
+                      >
+                        Delete lane
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </header>
+              <div
+                className="c15"
+              >
+                <div>
+                  <div
+                    className="smooth-dnd-draggable-wrapper"
+                  >
+                    <article
+                      className="react-trello-card c16 c17"
+                      data-id="Wip1"
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      <header
+                        className="c18"
+                      >
+                        <span
+                          className="c19"
+                          draggable={true}
+                        >
+                          Clean House
+                        </span>
+                        <span
+                          className="c20"
+                        >
+                          30 mins
+                        </span>
+                        <div
+                          className="c11"
+                          onClick={[Function]}
+                        >
+                          <button
+                            className="c21"
+                          >
+                            ✖
+                          </button>
+                        </div>
+                      </header>
+                      <div
+                        className="c22"
+                      >
+                        Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses
                       </div>
                     </article>
                   </div>
@@ -39380,6 +41010,115 @@ exports[`Storyshots I18n Custom texts 1`] = `
                                   }
                                 >
                                   '20/70'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                        
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'WIP'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    title
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Work In Progress'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    label
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  '10/20'
                                 </span>
                                 ,
                                 <span>
@@ -39982,6 +41721,24 @@ exports[`Storyshots I18n Flat translation table 1`] = `
               "label": "20/70",
               "title": "Sorted Lane",
             },
+            Object {
+              "cards": Array [
+                Object {
+                  "description": "Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses",
+                  "id": "Wip1",
+                  "label": "30 mins",
+                  "laneId": "WIP",
+                  "title": "Clean House",
+                },
+              ],
+              "currentPage": 1,
+              "id": "WIP",
+              "label": "10/20",
+              "style": Object {
+                "width": 280,
+              },
+              "title": "Work In Progress",
+            },
           ],
         }
       }
@@ -40236,6 +41993,144 @@ exports[`Storyshots I18n Flat translation table 1`] = `
                         className="c22"
                       >
                         Transfer to bank account
+                      </div>
+                    </article>
+                  </div>
+                </div>
+                <a
+                  className="c23"
+                  onClick={[Function]}
+                >
+                  Klicken zum Erstellen einer Karte
+                </a>
+              </div>
+            </section>
+          </div>
+          <div
+            className="smooth-dnd-draggable-wrapper"
+          >
+            <section
+              className="react-trello-lane c1"
+              draggable={false}
+              label="10/20"
+              onClick={[Function]}
+              style={
+                Object {
+                  "width": 280,
+                }
+              }
+              title="Work In Progress"
+            >
+              <header
+                className="c2"
+                onDoubleClick={[Function]}
+              >
+                <span
+                  className="c3"
+                  draggable={true}
+                  style={Object {}}
+                >
+                  Work In Progress
+                </span>
+                <span
+                  className="c4"
+                >
+                  <span
+                    style={Object {}}
+                  >
+                    10/20
+                  </span>
+                </span>
+                <div
+                  className="c5"
+                >
+                  <a
+                    className="fePDys"
+                    href=""
+                    onClick={[Function]}
+                  >
+                    <button
+                      className="c6"
+                    >
+                      ⋮
+                    </button>
+                  </a>
+                  <div
+                    className="c7 c8"
+                  >
+                    <div
+                      className="c9"
+                    >
+                      <span
+                        className="c10"
+                      >
+                        Listenaktionen
+                      </span>
+                      <div
+                        className="c11"
+                      >
+                        <button
+                          className="c12"
+                        >
+                          ✖
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      className="c13"
+                    >
+                      <div
+                        className="c14"
+                        onClick={[Function]}
+                      >
+                        Liste löschen
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </header>
+              <div
+                className="c15"
+              >
+                <div>
+                  <div
+                    className="smooth-dnd-draggable-wrapper"
+                  >
+                    <article
+                      className="react-trello-card c16 c17"
+                      data-id="Wip1"
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      <header
+                        className="c18"
+                      >
+                        <span
+                          className="c19"
+                          draggable={true}
+                        >
+                          Clean House
+                        </span>
+                        <span
+                          className="c20"
+                        >
+                          30 mins
+                        </span>
+                        <div
+                          className="c11"
+                          onClick={[Function]}
+                        >
+                          <button
+                            className="c21"
+                          >
+                            ✖
+                          </button>
+                        </div>
+                      </header>
+                      <div
+                        className="c22"
+                      >
+                        Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses
                       </div>
                     </article>
                   </div>
@@ -40568,6 +42463,115 @@ exports[`Storyshots I18n Flat translation table 1`] = `
                                   }
                                 >
                                   '20/70'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                        
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'WIP'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    title
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Work In Progress'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                          
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    label
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  '10/20'
                                 </span>
                                 ,
                                 <span>
@@ -41183,6 +43187,24 @@ exports[`Storyshots I18n Using i18next 1`] = `
                 "label": "20/70",
                 "title": "Sorted Lane",
               },
+              Object {
+                "cards": Array [
+                  Object {
+                    "description": "Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses",
+                    "id": "Wip1",
+                    "label": "30 mins",
+                    "laneId": "WIP",
+                    "title": "Clean House",
+                  },
+                ],
+                "currentPage": 1,
+                "id": "WIP",
+                "label": "10/20",
+                "style": Object {
+                  "width": 280,
+                },
+                "title": "Work In Progress",
+              },
             ],
           }
         }
@@ -41437,6 +43459,144 @@ exports[`Storyshots I18n Using i18next 1`] = `
                           className="c22"
                         >
                           Transfer to bank account
+                        </div>
+                      </article>
+                    </div>
+                  </div>
+                  <a
+                    className="c23"
+                    onClick={[Function]}
+                  >
+                    Click to add card
+                  </a>
+                </div>
+              </section>
+            </div>
+            <div
+              className="smooth-dnd-draggable-wrapper"
+            >
+              <section
+                className="react-trello-lane c1"
+                draggable={false}
+                label="10/20"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": 280,
+                  }
+                }
+                title="Work In Progress"
+              >
+                <header
+                  className="c2"
+                  onDoubleClick={[Function]}
+                >
+                  <span
+                    className="c3"
+                    draggable={true}
+                    style={Object {}}
+                  >
+                    Work In Progress
+                  </span>
+                  <span
+                    className="c4"
+                  >
+                    <span
+                      style={Object {}}
+                    >
+                      10/20
+                    </span>
+                  </span>
+                  <div
+                    className="c5"
+                  >
+                    <a
+                      className="fePDys"
+                      href=""
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="c6"
+                      >
+                        ⋮
+                      </button>
+                    </a>
+                    <div
+                      className="c7 c8"
+                    >
+                      <div
+                        className="c9"
+                      >
+                        <span
+                          className="c10"
+                        >
+                          Lane actions
+                        </span>
+                        <div
+                          className="c11"
+                        >
+                          <button
+                            className="c12"
+                          >
+                            ✖
+                          </button>
+                        </div>
+                      </div>
+                      <div
+                        className="c13"
+                      >
+                        <div
+                          className="c14"
+                          onClick={[Function]}
+                        >
+                          Delete lane
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </header>
+                <div
+                  className="c15"
+                >
+                  <div>
+                    <div
+                      className="smooth-dnd-draggable-wrapper"
+                    >
+                      <article
+                        className="react-trello-card c16 c17"
+                        data-id="Wip1"
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        <header
+                          className="c18"
+                        >
+                          <span
+                            className="c19"
+                            draggable={true}
+                          >
+                            Clean House
+                          </span>
+                          <span
+                            className="c20"
+                          >
+                            30 mins
+                          </span>
+                          <div
+                            className="c11"
+                            onClick={[Function]}
+                          >
+                            <button
+                              className="c21"
+                            >
+                              ✖
+                            </button>
+                          </div>
+                        </header>
+                        <div
+                          className="c22"
+                        >
+                          Soap wash and polish floor. Polish windows and doors. Scrap all broken glasses
                         </div>
                       </article>
                     </div>

--- a/tests/__snapshots__/Storyshots.test.js.snap
+++ b/tests/__snapshots__/Storyshots.test.js.snap
@@ -12154,7 +12154,7 @@ exports[`Storyshots Basic Functions Sorted Lane 1`] = `
                             }
                           }
                         >
-                          laneSortFunction
+                          compare
                         </span>
                         }
                       </span>


### PR DESCRIPTION
When I needed to use the `laneSortFunction` I notice that it's work fine in a single lane as showed in [the story example](https://rcdexta.com/react-trello/?selectedKind=Basic%20Functions&selectedStory=Sorted%20Lane&full=0&addons=0&stories=1&panelRight=0). But there's a bug when I have more than one lane. The react-trello gets confused with the new indexes and consequently move wrong cards on dragging and dropping.

I fixed the issue by reordering the cards before they were added on the lane.