### PR TITLE
Add missing `UPDATE_LANE` reducer

### DIFF
--- a/src/reducers/BoardReducer.js
+++ b/src/reducers/BoardReducer.js
@@ -15,6 +15,8 @@ const boardReducer = (state = {lanes: []}, action) => {
       return Lh.updateCardsForLane(state, payload)
     case 'UPDATE_LANES':
       return Lh.updateLanes(state, payload)
+    case 'UPDATE_LANE':
+      return Lh.updateLane(state, payload)
     case 'PAGINATE_LANE':
       return Lh.paginateLane(state, payload)
     case 'MOVE_LANE':


### PR DESCRIPTION
This adds a missing reducer, the action and function were both already defined. This also fixes the bug that editable titles would go back to their original value anytime the store updated.