### PR TITLE
Remove jsnext:main and module values in package.json as both point to…

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,6 @@
   "name": "react-trello",
   "description": "Pluggable components to add a trello like kanban board to your application",
   "main": "dist/index.js",
-  "jsnext:main": "src/components/index.js",
-  "module": "src/components/index.js",
   "files": [
     "src",
     "dist",


### PR DESCRIPTION
… modules that require more than ES2015 syntax.

For #359 