### PR TITLE
Add ability to update single card through event bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ const setEventBus = (handle) => {
 //To add a card
 eventBus.publish({type: 'ADD_CARD', laneId: 'COMPLETED', card: {id: "M1", title: "Buy Milk", label: "15 mins", description: "Also set reminder"}})
 
+//To update a card
+eventBus.publish({type: 'UPDATE_CARD', laneId: 'COMPLETED', card: {id: "M1", title: "Buy Milk (Updated)", label: "20 mins", description: "Also set reminder (Updated)"}})
+
 //To remove a card
 eventBus.publish({type: 'REMOVE_CARD', laneId: 'PLANNED', cardId: "M1"})
 

--- a/src/actions/LaneActions.js
+++ b/src/actions/LaneActions.js
@@ -1,6 +1,7 @@
 import {createAction} from 'redux-actions'
 
 export const addCard = createAction('ADD_CARD')
+export const updateCard = createAction('UPDATE_CARD')
 export const removeCard = createAction('REMOVE_CARD')
 export const moveCardAcrossLanes = createAction('MOVE_CARD')
 export const updateCards = createAction('UPDATE_CARDS')

--- a/src/controllers/BoardContainer.js
+++ b/src/controllers/BoardContainer.js
@@ -63,6 +63,8 @@ class BoardContainer extends Component {
         switch (event.type) {
           case 'ADD_CARD':
             return actions.addCard({laneId: event.laneId, card: event.card})
+          case 'UPDATE_CARD':
+            return actions.updateCard({laneId: event.laneId, card: event.card})
           case 'REMOVE_CARD':
             return actions.removeCard({laneId: event.laneId, cardId: event.cardId})
           case 'REFRESH_BOARD':

--- a/src/helpers/LaneHelper.js
+++ b/src/helpers/LaneHelper.js
@@ -69,6 +69,28 @@ const LaneHelper = {
     return update(state, {lanes: {$set: lanes}})
   },
 
+  updateCardFromLane: (state, {laneId, card}) => {
+    const laneIndex = state.lanes.findIndex(x => x.id === laneId)
+    if (laneIndex < 0) {
+      return state
+    }
+    const cardIndex = state.lanes[laneIndex].cards.findIndex(x => x.id == card.id)
+    if (cardIndex < 0) {
+      return state
+    }
+    return update(state, {
+      lanes: {
+        [laneIndex]: {
+          cards: {
+            [cardIndex]: {
+              $set: card
+            }
+          }
+        }
+      }
+    })
+  },
+
   moveCardAcrossLanes: (state, {fromLaneId, toLaneId, cardId, index}) => {
     let cardToMove = null
     const interimLanes = state.lanes.map(lane => {

--- a/src/helpers/LaneHelper.js
+++ b/src/helpers/LaneHelper.js
@@ -74,7 +74,7 @@ const LaneHelper = {
     if (laneIndex < 0) {
       return state
     }
-    const cardIndex = state.lanes[laneIndex].cards.findIndex(x => x.id == card.id)
+    const cardIndex = state.lanes[laneIndex].cards.findIndex(x => x.id === card.id)
     if (cardIndex < 0) {
       return state
     }

--- a/src/reducers/BoardReducer.js
+++ b/src/reducers/BoardReducer.js
@@ -7,6 +7,8 @@ const boardReducer = (state = {lanes: []}, action) => {
       return Lh.initialiseLanes(state, payload)
     case 'ADD_CARD':
       return Lh.appendCardToLane(state, payload)
+    case 'UPDATE_CARD':
+      return Lh.updateCardFromLane(state, payload)
     case 'REMOVE_CARD':
       return Lh.removeCardFromLane(state, payload)
     case 'MOVE_CARD':

--- a/stories/CustomNewCardForm.story.js
+++ b/stories/CustomNewCardForm.story.js
@@ -6,20 +6,20 @@ import Board from '../src'
 const data = require('./data/base.json')
 
 class NewCardForm extends Component {
+  handleAdd = () => this.props.onAdd({title: this.titleRef.value, description: this.descRef.value})
+  setTitleRef = (ref) => this.titleRef = ref
+  setDescRef = (ref) => this.descRef = ref
   render() {
     const {onCancel} = this.props
-    const handleAdd = () => this.props.onAdd({title: this.titleRef.value, desc: this.descRef.value})
-    const setTitleRef = (ref) => this.titleRef = ref
-    const setDescRef = (ref) => this.descRef = ref
     return (
       <div style={{background: 'white', borderRadius: 3, border: '1px solid #eee', borderBottom: '1px solid #ccc'}}>
         <div style={{padding: 5, margin: 5}}>
           <div>
             <div style={{marginBottom: 5}}>
-              <input type="text" ref={setTitleRef} placeholder="Title" />
+              <input type="text" ref={this.setTitleRef} placeholder="Title" />
             </div>
             <div style={{marginBottom: 5}}>
-              <input type="text" ref={setDescRef} placeholder="Description" />
+              <input type="text" ref={this.setDescRef} placeholder="Description" />
             </div>
           </div>
           <button onClick={this.handleAdd}>Add</button>

--- a/stories/Realtime.story.js
+++ b/stories/Realtime.story.js
@@ -43,6 +43,14 @@ class RealtimeBoard extends Component {
     this.setState({boardData: newData})
   }
 
+  updateCard = () => {
+    this.state.eventBus.publish({
+      type: 'UPDATE_CARD',
+      laneId: 'PLANNED',
+      card: {id: 'Plan2', title: 'UPDATED Dispose Garbage', label: '45 mins', description: 'UPDATED Sort out recyclable and waste as needed'}
+    })
+  }
+
   prioritizeWriteBlog = () => {
     this.state.eventBus.publish({
       type: 'MOVE_CARD',
@@ -75,6 +83,9 @@ class RealtimeBoard extends Component {
         </button>
         <button onClick={this.prioritizeWriteBlog} style={{margin: 5}}>
           Prioritize Write Blog
+        </button>
+        <button onClick={this.updateCard} style={{margin: 5}}>
+          Update Dispose Garbage
         </button>
         <Board data={this.state.boardData} onDataChange={this.shouldReceiveNewData} eventBusHandle={this.setEventBus} />
       </div>

--- a/tests/__snapshots__/Storyshots.test.js.snap
+++ b/tests/__snapshots__/Storyshots.test.js.snap
@@ -3781,6 +3781,16 @@ exports[`Storyshots Advanced Features Realtime Events 1`] = `
       >
         Prioritize Write Blog
       </button>
+      <button
+        onClick={[Function]}
+        style={
+          Object {
+            "margin": 5,
+          }
+        }
+      >
+        Update Dispose Garbage
+      </button>
       <div
         className="react-trello-board c0"
         data={


### PR DESCRIPTION
I've noticed that there is no clean way of updating single card in a lane. In this PR I've added ability to update single card by publishing action with type `UPDATE_CARD`