### PR TITLE
Removed title param/prop from Section and Header lane HTLM tags.

### DIFF
--- a/src/controllers/Lane.js
+++ b/src/controllers/Lane.js
@@ -253,14 +253,15 @@ class Lane extends Component {
     } = this.props
     const allClassNames = classNames('react-trello-lane', this.props.className || '')
     const showFooter = collapsibleLanes && cards.length > 0
+    const _otherProps = {...otherProps, title:''};
     return (
       <components.Section
-        {...otherProps}
+        {..._otherProps}
         key={id}
         onClick={() => onLaneClick && onLaneClick(id)}
         draggable={false}
         className={allClassNames}>
-        {this.renderHeader({id, cards, ...otherProps})}
+        {this.renderHeader({id, cards, ..._otherProps})}
         {this.renderDragContainer(isDraggingOver)}
         {loading && <components.Loader />}
         {showFooter && <components.LaneFooter onClick={this.toggleLaneCollapsed} collapsed={collapsed} />}


### PR DESCRIPTION
Just removed title prop from Section and Header lane HTLM tags to prevent undesired title/tooltip.

![react-trello title](https://user-images.githubusercontent.com/611060/88411838-011efb80-cdaf-11ea-8432-05e44016f9bf.png)
