### PR TITLE
Required laneId during on AddCardLink

### DIFF
--- a/src/components/AddCardLink.js
+++ b/src/components/AddCardLink.js
@@ -1,4 +1,4 @@
 import React from 'react'
 import {AddCardLink} from 'rt/styles/Base'
 
-export default ({onClick, t}) => <AddCardLink onClick={onClick}>{t('Click to add card')}</AddCardLink>
+export default ({onClick, t, laneId}) => <AddCardLink onClick={onClick}>{t('Click to add card')}</AddCardLink>

--- a/src/controllers/Lane.js
+++ b/src/controllers/Lane.js
@@ -198,7 +198,7 @@ class Lane extends Component {
           getChildPayload={index => this.props.getCardDetails(id, index)}>
           {cardList}
         </Container>
-        {editable && !addCardMode && <components.AddCardLink onClick={this.showEditableCard} t={t} />}
+        {editable && !addCardMode && <components.AddCardLink onClick={this.showEditableCard} t={t} laneId={id} />}
         {addCardMode && (
           <components.NewCardForm onCancel={this.hideEditableCard} t={t} laneId={id} onAdd={this.addNewCard} />
         )}
@@ -217,7 +217,7 @@ class Lane extends Component {
     this.props.onLaneUpdate(this.props.id, {title: value})
   }
 
-  renderHeader = (pickedProps) => {
+  renderHeader = pickedProps => {
     const {components} = this.props
     return (
       <components.LaneHeader


### PR DESCRIPTION
In a few cases, laneId is being required on adding a custom AddCardLink component.