### PR TITLE
Fix for #375 so that the id for a new lane is passed to onLaneAdd.

### DIFF
--- a/src/components/NewLaneForm.js
+++ b/src/components/NewLaneForm.js
@@ -3,10 +3,14 @@ import PropTypes from 'prop-types'
 import { LaneTitle, NewLaneButtons, Section } from 'rt/styles/Base'
 import { AddButton, CancelButton } from 'rt/styles/Elements'
 import NewLaneTitleEditor from 'rt/widgets/NewLaneTitleEditor'
+import uuidv1 from 'uuid/v1'
 
 class NewLane extends Component {
   handleSubmit = () => {
-    this.props.onAdd({ title: this.getValue() })
+    this.props.onAdd({ 
+        id: uuidv1(),
+        title: this.getValue() 
+    })
   }
 
   getValue = () => this.refInput.getValue()

--- a/src/helpers/LaneHelper.js
+++ b/src/helpers/LaneHelper.js
@@ -1,5 +1,4 @@
 import update from 'immutability-helper'
-import uuidv1 from 'uuid/v1'
 
 const LaneHelper = {
   initialiseLanes: (state, {lanes}) => {
@@ -42,7 +41,7 @@ const LaneHelper = {
   },
 
   addLane: (state, lane) => {
-    const newLane = {id: uuidv1(), cards: [], ...lane}
+    const newLane = {cards: [], ...lane}
     return update(state, {lanes: {$push: [newLane]}})
   },
 


### PR DESCRIPTION
 Moved generation of the lane id to an earlier stage so that it can be passed to the onLaneAdd callback in the same way as the id for a new card is passed to onCardAdd.

Fix for #375