### PR TITLE
Remove references to confusing second updateCard action

### DIFF
--- a/src/controllers/Lane.js
+++ b/src/controllers/Lane.js
@@ -142,7 +142,7 @@ class Lane extends Component {
   }
 
   updateCard = updatedCard => {
-    this.props.actions.updateCard({laneId: this.props.id, updatedCard})
+    this.props.actions.updateCard({laneId: this.props.id, card: updatedCard})
     this.props.onCardUpdate(this.props.id, updatedCard)
   }
 

--- a/src/helpers/LaneHelper.js
+++ b/src/helpers/LaneHelper.js
@@ -68,28 +68,6 @@ const LaneHelper = {
     return update(state, {lanes: {$set: lanes}})
   },
 
-  updateCardFromLane: (state, {laneId, card}) => {
-    const laneIndex = state.lanes.findIndex(x => x.id === laneId)
-    if (laneIndex < 0) {
-      return state
-    }
-    const cardIndex = state.lanes[laneIndex].cards.findIndex(x => x.id === card.id)
-    if (cardIndex < 0) {
-      return state
-    }
-    return update(state, {
-      lanes: {
-        [laneIndex]: {
-          cards: {
-            [cardIndex]: {
-              $set: card
-            }
-          }
-        }
-      }
-    })
-  },
-
   moveCardAcrossLanes: (state, {fromLaneId, toLaneId, cardId, index}) => {
     let cardToMove = null
     const interimLanes = state.lanes.map(lane => {
@@ -116,7 +94,7 @@ const LaneHelper = {
     return update(state, {lanes: {$set: lanes}})
   },
 
-  updateCardForLane: (state, {laneId, updatedCard}) => {
+  updateCardForLane: (state, {laneId, card: updatedCard}) => {
     const lanes = state.lanes.map(lane => {
       if (lane.id === laneId) {
         const cards = lane.cards.map(card => {

--- a/src/reducers/BoardReducer.js
+++ b/src/reducers/BoardReducer.js
@@ -7,8 +7,6 @@ const boardReducer = (state = {lanes: []}, action) => {
       return Lh.initialiseLanes(state, payload)
     case 'ADD_CARD':
       return Lh.appendCardToLane(state, payload)
-    case 'UPDATE_CARD':
-      return Lh.updateCardFromLane(state, payload)
     case 'REMOVE_CARD':
       return Lh.removeCardFromLane(state, payload)
     case 'MOVE_CARD':


### PR DESCRIPTION
This fixes #424 

In February and May of 2020, two different functions were added that both used the "UPDATE_CARD" event type. They had slightly different signatures (`{ laneId, card }` vs `{ laneId, updatedCard }`) but otherwise function very similarly.

`LaneHelper.updateCardFromLane()` (removed by this update) seems to have been intended for use by the event bus, whereas the other, `LaneHelper.updateCardForLane()` was added generically to grant edit functionality to cards.

This PR removes the references to `updateCardFromLane()` but preserves the signature to avoid breaking changes to code that uses it.

I originally kept `updateCardFromLane()` instead, but cursory testing showed that when making two updates to a card (e.g., first the description and then the label), the first update would be lost. This is not immediately apparent in the Storybook, but my use case (a StandardNotes editor) is tied directly to the `Board.onDataChange` prop. However, you can reproduce this issue in the Storybook by making those changes, then dragging the card to another lane.

This is because the Card component calls `updateCard()` only with the changes made, which `updateCardForLane()` handles, but `updateCardFromLane()` expects every field's new values to be passed to it. I think this is a net positive, but I don't know if any other projects that use react-trello might be relying on it as a way to clear fields or something similar.

My testing with these changes hasn't been extensive but I have not seen any issues (including the above described ones) thus far.