### PR TITLE
Update Lane.js

### DIFF
--- a/src/controllers/Lane.js
+++ b/src/controllers/Lane.js
@@ -26,8 +26,8 @@ class Lane extends Component {
     const node = evt.target
     const elemScrollPosition = node.scrollHeight - node.scrollTop - node.clientHeight
     const {onLaneScroll} = this.props
-    // In some browsers and/or screen sizes a decimal rest value between 0 and 1 exists, so it should be checked on < 1 instead of < 0
-    if (elemScrollPosition < 1 && onLaneScroll && !this.state.loading) {
+    // In some browsers and/or screen sizes a decimal rest value between 0 and 1 exists, so it should be checked on <= 1 instead of < 0
+    if (elemScrollPosition <= 1 && onLaneScroll && !this.state.loading) {
       const {currentPage} = this.state
       this.setState({loading: true})
       const nextPage = currentPage + 1


### PR DESCRIPTION
Would you please release this change? this should fix the 'onLaneScroll callback has not been triggered' issue permanently.

At a certain zoom level we get minimum  1 as the element position. I tried with all zoom levels, hence this fix should trigger onLaneScroll callback properly in screens of different sizes and at different zoom levels.

![image](https://user-images.githubusercontent.com/76739349/123370065-8ea93380-d59c-11eb-90a6-839a7a2b3dcb.png)

your release will help me a lot with my project, thanks a lot for earlier responses.
@rcdexta @dapi @oliviervanbulck @yashutanna