### PR TITLE
Control infinite scrolling

### DIFF
--- a/src/controllers/Lane.js
+++ b/src/controllers/Lane.js
@@ -25,9 +25,9 @@ class Lane extends Component {
   handleScroll = evt => {
     const node = evt.target
     const elemScrollPosition = node.scrollHeight - node.scrollTop - node.clientHeight
-    const {onLaneScroll} = this.props
+    const {onLaneScroll, cards, totalCardsCount} = this.props
     // In some browsers and/or screen sizes a decimal rest value between 0 and 1 exists, so it should be checked on < 1 instead of < 0
-    if (elemScrollPosition < 1 && onLaneScroll && !this.state.loading) {
+    if (elemScrollPosition < 1 && onLaneScroll && !this.state.loading && (!totalCardsCount || (totalCardsCount && totalCardsCount > cards.length))) {
       const {currentPage} = this.state
       this.setState({loading: true})
       const nextPage = currentPage + 1


### PR DESCRIPTION
Cases covered:
1. when we change zoom levels, if the scroll is already at the end of the lane, the loading animation is appearing infinitely.
2. if we want to stop the loading animation once the total number of records
3. new set of records are not getting loaded, because the scroll end logic is not working in all browsers of all screen sizes.

Fixes:
load the new set of records when the scroll is 10px above the scroll end until it reaches the total number of records in each lane
Conditionally & optionally stop the infinite scroll
fix pagination not working issue